### PR TITLE
Add VSCodium reference to editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Repozytorium **InfoHub** to centralne miejsce do przechowywania informacji, opis
 
 #### **Edytory i Środowiska Programistyczne**
 - **Visual Studio Code (VSCode)** – Edytor kodu <a href="https://code.visualstudio.com/" target="_blank">(Link)</a>.
+- **VSCodium** – Wersja open-source Visual Studio Code pozbawiona telemetrii <a href="https://vscodium.com/" target="_blank">(Link)</a>.
 - **GitHub** – Repozytorium kodu <a href="https://github.com/" target="_blank">(Link)</a>.
 
 ---


### PR DESCRIPTION
## Summary
- add VSCodium as an additional editor in the documentation with a link to its website

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e3f362c88320b00872e302e5cf5c)