### PR TITLE
Add TOR resource section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ InfoHub to centralne miejsce do przechowywania opisów technologii, aplikacji i 
 | 🌐 | [Networking](networking/README.md) | Firewall, routery, monitoring oraz usługi DNS i proxy. |
 | ⚙️ | [DevOps & Automation](devops/README.md) | Konteneryzacja, orkiestracja, automatyzacja oraz zdalne zarządzanie. |
 | 🤖 | [AI & Kreatywność](ai/README.md) | Narzędzia wspierane sztuczną inteligencją i kreatywne usługi. |
+| 🧅 | [TOR & Darknet](tor/README.md) | Narzędzia do pracy z siecią Tor, katalogi onion i OSINT dark web. |
 
 ## 📎 Dodatkowe materiały
 - [Projekt Ansible + Semaphore](<Ansible prj/README.md>)

--- a/tor/README.md
+++ b/tor/README.md
@@ -1,0 +1,39 @@
+# 🧅 TOR & Darknet Hub
+Zestaw narzędzi i katalogów wspierających pracę w sieci Tor oraz analizę zasobów dark web i powiązanych baz wycieków.
+
+## 🧭 Spis treści
+- [Przeglądarki i dostęp](#przeglądarki-i-dostęp)
+- [Wyszukiwarki i katalogi .onion](#wyszukiwarki-i-katalogi-onion)
+- [OSINT, wycieki i bazy danych](#osint-wycieki-i-bazy-danych)
+- [Dodatkowe narzędzia](#dodatkowe-narzędzia)
+
+---
+
+### Przeglądarki i dostęp
+- **TOR Browser** – oficjalna przeglądarka Tor zapewniająca anonimowy dostęp do sieci onion. <a href="https://www.torproject.org/" target="_blank">(Strona)</a>
+- **TOR2web** – proxy umożliwiające dostęp do usług .onion z tradycyjnej przeglądarki. <a href="https://github.com/globaleaks/Tor2web" target="_blank">(Repo)</a>
+
+### Wyszukiwarki i katalogi .onion
+- **Ahmia** – wyszukiwarka usług onion, filtrowanie treści nielegalnych. <a href="https://ahmia.fi/" target="_blank">(Strona)</a>
+- **HayStack** – wyszukiwarka dark web (brak oficjalnego repo GitHub, projekty zamknięte).
+- **Tor66** – mirror search dla usług onion (brak oficjalnego repo, dostępne tylko w sieci Tor).
+- **Torch** – jedna z najstarszych wyszukiwarek .onion (brak oficjalnego repo).
+- **Onion Engine** – indeks części katalogów onion (brak oficjalnego repo publicznego).
+- **DarkwebDaily.Live** – katalog usług onion aktualizowany codziennie (brak repo).
+- **Onion.live** – interaktywny katalog serwisów .onion. <a href="https://onion.live/" target="_blank">(Strona)</a>
+- **Tor.link** – zbiór linków .onion (brak repo).
+- **The Hidden Wiki** – rozproszony katalog onion, liczne nieoficjalne mirrory (brak jednego repo).
+- **TorCrawl.py** – crawler do indeksowania usług Tor, dostępny jedynie w nieoficjalnych klonach (brak pewnego repo źródłowego).
+
+### OSINT, wycieki i bazy danych
+- **Telemetry** – narzędzie OSINT do wyszukiwania w Telegramie (brak oficjalnego repo).
+- **Library of Leaks** – kolekcja wycieków danych utrzymywana w prywatnych mirrorach (brak repo).
+- **HaveIBeenPwned** – API do weryfikacji naruszeń danych. <a href="https://haveibeenpwned.com/API/v3" target="_blank">(API)</a>
+- **DeHashed** – komercyjna baza wycieków i narzędzie OSINT. <a href="https://www.dehashed.com/" target="_blank">(Strona)</a>
+- **LeakOSINT** – bot Telegram skupiony na wyciekach danych (brak repo).
+- **UniversalSearchBot** – bot Telegram do wyszukiwania w danych z dark web (brak repo).
+- **DeepDarkCTI** – projekt monitorowania dark web i cyber threat intelligence. <a href="https://github.com/fastfire/deepdarkCTI" target="_blank">(Repo)</a>
+- **Aleph** – platforma do analizy dokumentów i danych wyciekowych. <a href="https://github.com/alephdata/aleph" target="_blank">(Repo)</a>
+
+### Dodatkowe narzędzia
+- **PGP Tool** – zestaw narzędzi do szyfrowania PGP; wersja desktop <a href="https://www.pgptool.com/" target="_blank">(Strona)</a> oraz implementacja open source <a href="https://github.com/vbuterin/PGP-Tool" target="_blank">(Repo)</a>.


### PR DESCRIPTION
## Summary
- add a dedicated `tor` directory with a README that describes common Tor, darkweb search, and OSINT tools
- extend the main README table of contents with a link to the new section

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b187f7a788320965190ba22168ffa)