### PR TITLE
Remove emojis from InfoHub documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # InfoHub
 InfoHub to centralne miejsce do przechowywania opisów technologii, aplikacji i narzędzi wykorzystywanych w środowisku IT. Znajdziesz tutaj szybkie zestawienia linków oraz dokumentację pomocną w codziennej pracy administratorów i entuzjastów nowych rozwiązań.
 
-## 📂 Spis treści
-| Ikona | Obszar | Opis |
-| --- | --- | --- |
-| 🧩 | [Software](software/README.md) | Oprogramowanie serwerowe, aplikacje multimedialne, narzędzia IT oraz rozwiązania desktopowe. |
-| 🌐 | [Networking](networking/README.md) | Firewall, routery, monitoring oraz usługi DNS i proxy. |
-| ⚙️ | [DevOps & Automation](devops/README.md) | Konteneryzacja, orkiestracja, automatyzacja oraz zdalne zarządzanie. |
-| 🤖 | [AI Hub](ai/README.md) | Narzędzia wspierane sztuczną inteligencją i innowacyjne usługi. |
-| 🧅 | [TOR & Darknet](tor/README.md) | Narzędzia do pracy z siecią Tor, katalogi onion i OSINT dark web. |
+## Spis treści
+| Obszar | Opis |
+| --- | --- |
+| [Software](software/README.md) | Oprogramowanie serwerowe, aplikacje multimedialne, narzędzia IT oraz rozwiązania desktopowe. |
+| [Networking](networking/README.md) | Firewall, routery, monitoring oraz usługi DNS i proxy. |
+| [DevOps & Automation](devops/README.md) | Konteneryzacja, orkiestracja, automatyzacja oraz zdalne zarządzanie. |
+| [AI Hub](ai/README.md) | Narzędzia wspierane sztuczną inteligencją i innowacyjne usługi. |
+| [TOR & Darknet](tor/README.md) | Narzędzia do pracy z siecią Tor, katalogi onion i OSINT dark web. |
 
-## 📎 Dodatkowe materiały
+## Dodatkowe materiały
 - [Projekt Ansible + Semaphore](<Ansible prj/README.md>)
 - [Hosting i Panel Administracyjny](<Hosting i Panel Administracyjny.md>)
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,7 +1,7 @@
-# 🤖 AI Hub
+# AI Hub
 Kompendium narzędzi, modeli i raportów o sztucznej inteligencji. Hub obejmuje zarówno praktyczne zastosowania (chatboty, IDE z AI, generatory obrazów), jak i eksperymentalne projekty badawcze.
 
-## 🧭 Spis treści
+## Spis treści
 - [Raport: Ocena najpopularniejszych systemów AI — listopad 2025](#raport-ocena-najpopularniejszych-systemów-ai--listopad-2025)
   - [Top 10 ogólnie](#top-10-ogólnie)
   - [Najważniejsze wnioski 2025](#najważniejsze-wnioski-2025)

--- a/devops/README.md
+++ b/devops/README.md
@@ -1,7 +1,7 @@
-# ⚙️ DevOps & Automation Hub
+# DevOps & Automation Hub
 Zbiór narzędzi do konteneryzacji, orkiestracji, automatyzacji oraz zdalnego zarządzania infrastrukturą.
 
-## 🧭 Spis treści
+## Spis treści
 - [Konteneryzacja (Docker)](#konteneryzacja-docker)
 - [Konteneryzacja i Klasteryzacja](#konteneryzacja-i-klasteryzacja)
 - [Automatyzacja i DevOps](#automatyzacja-i-devops)

--- a/networking/README.md
+++ b/networking/README.md
@@ -1,7 +1,7 @@
-# 🌐 Networking Hub
+# Networking Hub
 Lista narzędzi sieciowych z podziałem na firewall, zarządzanie, monitoring oraz usługi DNS/Proxy.
 
-## 🧭 Spis treści
+## Spis treści
 - [Sieciowe](#sieciowe)
   - [Firewall i Routery](#firewall-i-routery)
   - [Zarządzanie](#zarzadzanie)

--- a/software/README.md
+++ b/software/README.md
@@ -1,7 +1,7 @@
-# 🧩 Software Hub
+# Software Hub
 Centralny katalog aplikacji, systemów i narzędzi wspierających codzienną pracę administratorów oraz zespołów IT.
 
-## 🧭 Spis treści
+## Spis treści
 - [Oprogramowania](#oprogramowania)
   - [Serwerowe](#serwerowe)
     - [Hiperwizor typu 1](#hiperwizor-typu-1)

--- a/tor/README.md
+++ b/tor/README.md
@@ -1,7 +1,7 @@
-# 🧅 TOR & Darknet Hub
+# TOR & Darknet Hub
 Zestaw narzędzi i katalogów wspierających pracę w sieci Tor oraz analizę zasobów dark web i powiązanych baz wycieków.
 
-## 🧭 Spis treści
+## Spis treści
 - [Przeglądarki i dostęp](#przeglądarki-i-dostęp)
 - [Wyszukiwarki i katalogi .onion](#wyszukiwarki-i-katalogi-onion)
 - [OSINT, wycieki i bazy danych](#osint-wycieki-i-bazy-danych)


### PR DESCRIPTION
## Summary
- remove emoji-based headings and table columns from the root README to keep the navigation accessible in any environment
- update each hub README to use plain-text titles and tables of contents so the documentation renders consistently without special symbols

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b345e60d08320a239dfdd7d0c0581)