### PR TITLE
Add IPAM resources and documentation platforms

### DIFF
--- a/networking/README.md
+++ b/networking/README.md
@@ -23,6 +23,8 @@ Lista narzędzi sieciowych z podziałem na firewall, zarządzanie, monitoring or
 #### Zarządzanie
 - **FreshRSS** – Samohostowane oprogramowanie do czytnika RSS <a href="https://www.freshrss.org/" target="_blank">(Link)</a>.
 - **evillimiter** – Ograniczanie przepustowości sieci <a href="https://github.com/bitbrute/evillimiter" target="_blank">(Link)</a>.
+- **phpIPAM** – System IPAM do zarządzania adresacją i VLAN-ami <a href="https://phpipam.net/download/" target="_blank">(Link)</a>.
+- **NetBox** – DCIM i IPAM do modelowania infrastruktury i automatyzacji sieci <a href="https://github.com/netbox-community/netbox" target="_blank">(Repo)</a>.
 - **Omada Controller** – Oficjalny kontroler sieci TP-Link Omada (AP, switche, bramy) <a href="https://github.com/mbentley/docker-omada-controller" target="_blank">(Link)</a>.
 - **NetBird** – Zero-trust overlay network oparta o WireGuard <a href="https://github.com/netbirdio/netbird" target="_blank">(Link)</a>.
 - **Porównanie Tailscale, NetBird, Netmaker, Zerotier i Twingate** – Kompleksowa analiza VPN/Overlay/Zero-Trust <a href="./porownanie-tailscale-netbird-netmaker-zerotier-twingate.md">(Artykuł)</a>.

--- a/software/README.md
+++ b/software/README.md
@@ -136,6 +136,10 @@ Centralny katalog aplikacji, systemów i narzędzi wspierających codzienną pra
 - **IronCalc** – Arkusz kalkulacyjny online z obsługą formuł i importów <a href="https://github.com/ironcalc/IronCalc" target="_blank">(Link)</a>
 - **Paperless-ngx** – System OCR i zarządzania dokumentami dla self-hosted <a href="https://github.com/paperless-ngx/paperless-ngx" target="_blank">(Link)</a>
 - **Linkwarden** – Samohostowany menedżer zakładek z funkcjami archiwizacji <a href="https://github.com/linkwarden/linkwarden/tree/main" target="_blank">(Link)</a>
+- **GitBook** – Platforma do tworzenia dokumentacji i baz wiedzy <a href="https://github.com/GitbookIO/gitbook" target="_blank">(Repo)</a> | <a href="https://www.gitbook.com/" target="_blank">(Strona)</a>
+- **Featurebase** – Alternatywa dla GitBooka do zbierania feedbacku i prowadzenia bazy wiedzy <a href="https://www.featurebase.app/alternative/gitbook?gad_campaignid=22965331894" target="_blank">(Link)</a>
+- **KaraKeep** – Lekka wiki i system notatek w stylu Markdown <a href="https://karakeep.app/" target="_blank">(Strona)</a> | <a href="https://github.com/karakeep-app/karakeep" target="_blank">(Repo)</a>
+- **Wiki.js** – Samohostowana platforma wiki oparta na Node.js <a href="https://js.wiki/" target="_blank">(Link)</a>
 
 ##### Narzędzia
 - **it-tools** – Narzędzia IT w przeglądarce <a href="https://it-tools.tech/" target="_blank">(Link)</a>


### PR DESCRIPTION
## Summary
- add phpIPAM and NetBox to the networking management catalog
- add documentation and wiki platforms such as GitBook, Featurebase, KaraKeep, and Wiki.js to productivity tools

## Testing
- not run (documentation updates)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1ff3d9c4832080d102e4c600cf32)