### PR TITLE
Add default repository scan and exclude support to link checker

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -4,7 +4,7 @@ Kompendium narzędzi, modeli i raportów o sztucznej inteligencji. Hub obejmuje 
 ## Proces review
 - Aktualizujemy zestawienia i komentarze kwartalnie lub częściej, jeżeli pojawią się przełomowe wyniki benchmarków.
 - Każdą zmianę przechodzi ręczny przegląd dwóch osób odpowiedzialnych za daną domenę (asystenci, obrazowanie, dev tooling).
-- Linki do dokumentacji i raportów są weryfikowane automatycznie przy pomocy skryptu [`scripts/check_links.py`](../scripts/check_links.py), który sprawdza odpowiedź HTTP 200 dla wszystkich adresów.
+- Linki do dokumentacji i raportów są weryfikowane automatycznie przy pomocy skryptu [`scripts/check_links.py`](../scripts/check_links.py), który domyślnie skanuje całe repozytorium (można pominąć katalogi typu `scripts`/`venv` przez `--exclude`) i sprawdza odpowiedź HTTP 200 dla wszystkich adresów.
 
 ## Spis treści
 - [Raport: Ocena najpopularniejszych systemów AI — listopad 2025](#raport-ocena-najpopularniejszych-systemów-ai--listopad-2025)

--- a/software/README.md
+++ b/software/README.md
@@ -4,7 +4,7 @@ Centralny katalog aplikacji, systemów i narzędzi wspierających codzienną pra
 ## Proces review
 - Aktualizujemy wpisy kwartalnie w ramach przeglądu technologii infrastrukturalnych i desktopowych.
 - Każda zmiana jest zatwierdzana w formule peer-review przez co najmniej dwie osoby odpowiedzialne za daną kategorię narzędzi.
-- Raz w tygodniu uruchamiamy skrypt [`scripts/check_links.py`](../scripts/check_links.py), aby upewnić się, że wszystkie odnośniki HTTP nadal odpowiadają kodem 200.
+- Raz w tygodniu uruchamiamy skrypt [`scripts/check_links.py`](../scripts/check_links.py), który domyślnie skanuje całe repozytorium (z opcją pomijania katalogów typu `scripts`/`venv` przez `--exclude`), aby upewnić się, że wszystkie odnośniki HTTP nadal odpowiadają kodem 200.
 
 ## Spis treści
 - [Oprogramowania](#oprogramowania)


### PR DESCRIPTION
## Summary
- default the link checker to scanning the entire repository and allow skipping directories via a new --exclude flag
- update README notes to reflect the new default behavior and exclusion option
- ensure markdown discovery respects excluded directories for both relative and absolute paths

## Testing
- python scripts/check_links.py --exclude scripts --exclude venv --max-workers 4 --timeout 5
- python scripts/check_links.py $(pwd)/ai --exclude scripts --exclude venv --max-workers 2 --timeout 5

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692479dbae508320a7c54a047d9b0d20)