### PR TITLE
Add scheduled link checker workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,21 @@
+name: Link Checker
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check links
+        run: python scripts/check_links.py

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ InfoHub to centralne miejsce do przechowywania opisów technologii, aplikacji i 
 | [Community projects](community-projects/README.md) | Katalog repozytoriów community open-source z podziałem na kategorie. |
 | [TOR & Darknet](tor/README.md) | Narzędzia do pracy z siecią Tor, katalogi onion i OSINT dark web. |
 
+## Automatyczne sprawdzanie linków
+- Workflow **Link Checker** uruchamia `scripts/check_links.py` dla całego repozytorium co poniedziałek o 06:00 UTC oraz na żądanie przez `Run workflow` w zakładce **Actions**.
+- Wyniki sprawdzenia znajdują się w logach jobu; niedziałające adresy są wypisywane jako wpisy `[FAIL]` z listą plików, w których występują.
+
 ## Dodatkowe materiały
 - [Hosting i Panel Administracyjny](<Hosting i Panel Administracyjny.md>)
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run the link checker on a schedule or manually
- document the link checker workflow and where to view results in the main README

## Testing
- not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692479ee1edc832094a8a6f5f1f53a23)