### PR TITLE
Add Termix SSH client link to community projects

### DIFF
--- a/community-projects/README.md
+++ b/community-projects/README.md
@@ -233,4 +233,5 @@ Repozytorium projektów community z GitHuba.
 - **Stacks** - infrastruktura IaC do deployu usług. [Link](https://github.com/zelestcarlyone/stacks)
 - **Reclaimarr** - agregator multimediów self-hosted. [Link](https://github.com/Okhr/reclaimarr)
 - **Walrus** - magazyn danych odporne na cenzurę. [Link](https://github.com/PolymathicAI/walrus)
+- **Termix** - klient SSH rozwijany przez społeczność. [Link](https://github.com/Termix-SSH/Termix)
 


### PR DESCRIPTION
## Summary
- add Termix community SSH client link under networking and security projects

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927144b0a488320a7b74343d1f7ae4d)